### PR TITLE
fix: stabilize Tor scans with atago e2e

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,16 +7,21 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+
 jobs:
-  integration_test:
-    name: Integration test with coverage (linux)
+  coverage:
+    name: Coverage (unit + atago E2E)
 
     strategy:
       matrix:
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@v7
@@ -31,7 +36,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y tor
 
-      - name: Run integration tests with coverage
-        run: go test -cover -coverpkg=./... -coverprofile=coverage.out ./...
+      - name: Install atago
+        uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
+        with:
+          version: v0.21.0
+
+      - name: Run combined unit and E2E coverage
+        run: make coverage
 
       - uses: k1LoW/octocov-action@v1
+        with:
+          config: .octocov.yml
+          work-dir: .
+          args: --report=coverage.out

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -32,4 +32,3 @@ jobs:
 
       - name: Run unit tests with coverage report output
         run: go test -short -cover -coverpkg=./... -coverprofile=coverage.out ./...
-

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Code coverage profiles and other test artifacts
 *.out
 /coverage.*
+/.coverage/
 *.coverprofile
 profile.cov
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-short clean help tools changelog lint
+.PHONY: build test test-short test-integration e2e coverage clean help lint
 
 APP         = onionscan
 VERSION     = $(shell git describe --tags --abbrev=0)
@@ -23,15 +23,22 @@ build:  ## Build binary
 	env GO111MODULE=on GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(GO_LDFLAGS) -o $(APP) ./cmd/$(APP)
 
 clean: ## Clean project
-	-rm -rf $(APP) coverage*
+	-rm -rf $(APP) coverage* .coverage
 
-test: ## Run all tests including integration tests (may take 10+ minutes)
-	env GOOS=$(GOOS) $(GO_TEST) -cover -coverpkg=$(GO_PKGROOT) -coverprofile=coverage.out $(GO_PKGROOT)
+test: ## Run unit tests
+	env GOOS=$(GOOS) $(GO_TEST) -short -cover -coverpkg=$(GO_PKGROOT) -coverprofile=coverage.out $(GO_PKGROOT)
 	-$(GO_TOOL) cover -html=coverage.out -o coverage.html
 
-test-short: ## Run fast unit tests only (excludes integration tests)
-	env GOOS=$(GOOS) $(GO_TEST) -cover -coverpkg=$(GO_PKGROOT) -coverprofile=coverage.out -short $(GO_PKGROOT)
-	-$(GO_TOOL) cover -html=coverage.out -o coverage.html
+test-short: test ## Alias for test
+
+test-integration: ## Run the opt-in legacy real-Tor Go integration tests
+	env ONIONSCAN_RUN_TOR_INTEGRATION=1 $(GO_TEST) -timeout 45m ./cmd/onionscan
+
+e2e: ## Run atago E2E against a tornago-hosted onion service
+	./e2e/run.sh
+
+coverage: ## Combine unit and atago E2E coverage
+	./scripts/coverage.sh
 
 lint: ## Run golangci-lint
 	golangci-lint run

--- a/README.md
+++ b/README.md
@@ -1,435 +1,274 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/nao1215/onionscan.svg)](https://pkg.go.dev/github.com/nao1215/onionscan)
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/onionscan)](https://goreportcard.com/report/github.com/nao1215/onionscan)
-[![MultiPlatformUnitTest](https://github.com/nao1215/onionscan/actions/workflows/unit_test.yml/badge.svg)](https://github.com/nao1215/onionscan/actions/workflows/unit_test.yml)
+[![Multi-platform unit tests](https://github.com/nao1215/onionscan/actions/workflows/unit_test.yml/badge.svg)](https://github.com/nao1215/onionscan/actions/workflows/unit_test.yml)
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/onionscan/coverage.svg)
+[![tested with atago](https://img.shields.io/badge/tested%20with-atago-7c3aed?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI%2BPHBhdGggZmlsbD0iI2ZmZiIgZD0iTTMuNiA0LjIgMTEuOSAxMmwtOC4zIDcuOC0xLjktMi4yTDcuOSAxMiAxLjcgNi40eiIvPjxyZWN0IGZpbGw9IiNmZmYiIHg9IjEyLjYiIHk9IjE3LjIiIHdpZHRoPSI5LjciIGhlaWdodD0iMi44IiByeD0iMS40Ii8%2BPC9zdmc%2B&logoColor=white)](https://github.com/nao1215/atago)
+![GitHub license](https://img.shields.io/github/license/nao1215/onionscan)
+[![GitHub downloads](https://img.shields.io/github/downloads/nao1215/onionscan/total)](https://github.com/nao1215/onionscan/releases)
 
 # OnionScan
 
-![logo](./doc/images/logo.png)
+![OnionScan logo](./doc/images/logo.png)
 
-OnionScan is a security auditing tool for Tor hidden services (.onion addresses). It identifies OPSEC issues, configuration errors, and anonymity risks that could deanonymize hidden service operators.
+OnionScan audits Tor v3 onion services for operational-security mistakes, exposed identity signals, vulnerable server configuration, and unexpected network services. It starts Tor for you or uses an existing SOCKS5 proxy, crawls the target, runs focused analyzers, and writes text, JSON, or Markdown reports.
 
-This project is a complete rewrite inspired by the original [s-rah/onionscan](https://github.com/s-rah/onionscan), which had not been maintained for several years. Major enhancements include:
-
-- **Tor v3 Support**: Full support for v3 onion addresses (56-character `.onion` addresses using ed25519 keys)
-- **Embedded Tor**: No need to manually configure Tor - the tool handles it automatically
-- **Enhanced Analyzers**: Additional security checks for modern threats (browser fingerprinting, API leaks, cloud services)
-- **Multiple Output Formats**: JSON, Markdown, and text reports with severity-based categorization
-- **Modern Go Codebase**: Built from scratch with Go 1.25+, clean architecture, and comprehensive test coverage
+This is a modern Go rewrite inspired by [s-rah/onionscan](https://github.com/s-rah/onionscan). It supports current 56-character onion addresses, concurrent scans, per-site configuration, scan history, and comparison reports.
 
 > [!IMPORTANT]
-> **Legal Notice**: This tool is intended for legitimate purposes only, such as security research, penetration testing with authorization, and privacy auditing of your own services. Users are solely responsible for ensuring their use complies with all applicable laws and regulations. Do not use this tool for any illegal activities.
+> Use OnionScan only for services you own or are explicitly authorized to assess. You are responsible for complying with applicable laws and the target owner's rules.
 
-## Features
+## What it checks
 
-- **Embedded Tor Support**: Automatically starts a Tor daemon - no manual Tor configuration required
-- **Comprehensive Security Analysis**: 16+ analyzers covering various attack vectors
-- **Multiple Output Formats**: Text, JSON, and Markdown reports
-- **Multi-Protocol Scanning**: HTTP/HTTPS, SSH, FTP, SMTP, and database protocols
-- **Web Crawling**: Deep analysis with configurable crawl depth
-- **Site-Specific Configuration**: Custom cookies, headers, and patterns per target
+| Area | Examples |
+|------|----------|
+| Identity leaks | Email addresses, social profiles, analytics IDs, cryptocurrency addresses |
+| Sensitive material | Tor, SSH, cloud, API, and private-key patterns |
+| Web metadata | EXIF data, server banners, external links, cloud resources |
+| Browser behavior | Canvas, WebGL, WebRTC, AudioContext, redirects, hidden iframes |
+| API exposure | OpenAPI, Swagger, GraphQL, debug endpoints, environment references |
+| Web hardening | Security headers, CSP, cookies, TLS, Apache status pages |
+| Network services | HTTP, HTTPS, SSH, FTP, SMTP, MongoDB, Redis, PostgreSQL, MySQL |
 
-## Security Checks
-
-### Deanonymization Risks
-| Category | Description |
-|----------|-------------|
-| Email Addresses | Detects email addresses that could identify operators |
-| Analytics IDs | Google Analytics, Facebook Pixel, and 11 other tracking services |
-| Cryptocurrency Addresses | Bitcoin, Ethereum, Monero, and 8 other cryptocurrencies |
-| Social Media Links | 16 platforms including Twitter, GitHub, Telegram |
-| EXIF Metadata | GPS coordinates, camera info, timestamps in images |
-| Private Keys | Tor keys, SSH keys, AWS credentials, API tokens |
-
-### Security Misconfigurations
-| Category | Description |
-|----------|-------------|
-| Server Headers | Version disclosure, security header analysis |
-| Apache mod_status | Exposed server status pages |
-| SSL/TLS Issues | Certificate problems, weak configurations |
-| CSP Analysis | Content Security Policy weaknesses |
-
-### Attack Surface Detection
-| Category | Description |
-|----------|-------------|
-| Browser Fingerprinting | Canvas, WebGL, WebRTC, AudioContext fingerprinting |
-| Malicious Patterns | Obfuscated JavaScript, hidden iframes, suspicious redirects |
-| API Leaks | Swagger/OpenAPI, GraphQL endpoints, debug interfaces |
-| Cloud Services | AWS, GCP, Azure, Cloudflare resource detection |
-
-### Protocol Scanners
-| Protocol | Port | Description |
-|----------|------|-------------|
-| HTTP/HTTPS | 80/443 | Web service detection and analysis |
-| SSH | 22 | Banner grabbing, OS detection |
-| FTP | 21 | Server software identification |
-| SMTP | 25 | Mail server hostname extraction |
-| MongoDB | 27017 | Database exposure detection |
-| Redis | 6379 | Unauthenticated access detection |
-| PostgreSQL | 5432 | Database service detection |
-| MySQL | 3306 | Version disclosure analysis |
+The crawler supports configurable depth, page limits, delays, response-size limits, headers, cookies, and allow or ignore patterns. Sensitive values in logs are redacted automatically.
 
 ## Requirements
 
-- **Go**: 1.25 or later
-- **Tor**: Must be installed on your system (for embedded mode)
+- Go 1.25 or later when building from source
+- A `tor` executable on `PATH`
 
-### Installing Tor
+Install Tor with the package manager for your platform:
 
-```bash
-# Ubuntu/Debian
-sudo apt update && sudo apt install tor
+```shell
+# Ubuntu or Debian
+sudo apt update
+sudo apt install tor
 
-# Fedora/RHEL
+# Fedora or RHEL
 sudo dnf install tor
 
 # Arch Linux
 sudo pacman -S tor
 
-# macOS (Homebrew)
+# macOS
 brew install tor
 
-# Windows (Chocolatey)
+# Windows
 choco install tor
 ```
 
-## Installation
+## Install
 
-### Homebrew (macOS/Linux)
+### Homebrew
 
-```bash
+```shell
 brew install nao1215/tap/onionscan
 ```
 
-### Go Install
+### Go
 
-```bash
+```shell
 go install github.com/nao1215/onionscan/cmd/onionscan@latest
 ```
 
-### Build from Source
+### Source
 
-```bash
+```shell
 git clone https://github.com/nao1215/onionscan.git
 cd onionscan
 go build -o onionscan ./cmd/onionscan
 ```
 
-## Quick Start
+Release archives are available from the [GitHub Releases page](https://github.com/nao1215/onionscan/releases).
 
-### Basic Scan
+## Quick start
 
-```bash
-# Scan a hidden service (starts embedded Tor automatically)
-onionscan scan exampleonion.onion
+Scan one service with an automatically managed Tor process:
 
-# Scan multiple services
-onionscan scan site1.onion site2.onion site3.onion
+```shell
+onionscan scan your-service.onion
 ```
 
-### Using External Tor
+Use a Tor daemon that is already running:
 
-If you already have Tor running:
-
-```bash
-# Use existing Tor SOCKS proxy
-onionscan scan --external-tor 127.0.0.1:9050 exampleonion.onion
-
-# Use Tor Browser's proxy
-onionscan scan --external-tor 127.0.0.1:9150 exampleonion.onion
+```shell
+onionscan scan --external-tor 127.0.0.1:9050 your-service.onion
 ```
 
-### Output Formats
+Scan several services concurrently:
 
-```bash
-# JSON report
-onionscan scan --json -o report.json exampleonion.onion
-
-# Markdown report
-onionscan scan --markdown -o report.md exampleonion.onion
-
-# Text report to file
-onionscan scan -o report.txt exampleonion.onion
+```shell
+onionscan scan --batch 3 first-service.onion second-service.onion third-service.onion
 ```
 
-### Scan Options
+Write machine-readable or review-friendly reports:
 
-```bash
-# Custom crawl depth
-onionscan scan --depth 50 exampleonion.onion
-
-# Limit maximum pages to crawl
-onionscan scan --max-pages 200 exampleonion.onion
-
-# Custom timeout
-onionscan scan --timeout 3m exampleonion.onion
-
-# Verbose logging
-onionscan scan -v exampleonion.onion
-
-# Concurrent scans
-onionscan scan --batch 5 site1.onion site2.onion site3.onion
+```shell
+onionscan scan --json --output report.json your-service.onion
+onionscan scan --markdown --output report.md your-service.onion
 ```
 
-### CLI Options Reference
+Tune the crawl for an authorized test:
 
-| Flag | Short | Default | Description |
-|------|-------|---------|-------------|
-| `--external-tor` | `-e` | (embedded) | Use external Tor proxy (e.g., `127.0.0.1:9050`) |
-| `--tor-timeout` | `-T` | `3m` | Timeout for embedded Tor startup |
-| `--timeout` | `-t` | `2m` | Connection timeout for each request |
-| `--depth` | `-d` | `100` | Maximum crawl recursion depth |
-| `--max-pages` | `-p` | `100` | Maximum pages to crawl per service |
-| `--batch` | `-b` | `10` | Number of concurrent scans |
-| `--config` | `-c` | `.onionscan` | Configuration file path |
-| `--json` | `-j` | `false` | Output JSON report |
-| `--markdown` | `-m` | `false` | Output Markdown report |
-| `--output` | `-o` | (stdout) | Write report to file |
-| `--verbose` | `-v` | `false` | Enable verbose logging |
-| `--crawl-delay` | `-D` | `1s` | Delay between HTTP requests (politeness setting) |
-| `--user-agent` | `-A` | `OnionScan/2.0` | User-Agent header for HTTP requests |
-| `--max-body-size` | `-B` | `5MB` | Maximum response body size in bytes |
-
-> [!NOTE]
-> **Batch Mode Limitation**: When using `--batch` with a value greater than 1, site-specific configurations (cookies, headers, depth) are ignored. Use `--batch 1` to apply per-site settings from your configuration file.
-
-### Politeness Settings
-
-OnionScan includes "politeness" settings to avoid overwhelming hidden services:
-
-```bash
-# Slower, more polite scanning (2 second delay)
-onionscan scan --crawl-delay 2s exampleonion.onion
-
-# Faster scanning for authorized testing (500ms delay)
-onionscan scan --crawl-delay 500ms exampleonion.onion
-
-# Custom User-Agent
-onionscan scan --user-agent "MyScanner/1.0" exampleonion.onion
-
-# Limit response body size (useful for memory-constrained environments)
-onionscan scan --max-body-size 1048576 exampleonion.onion  # 1MB
+```shell
+onionscan scan \
+  --depth 25 \
+  --max-pages 100 \
+  --timeout 3m \
+  --crawl-delay 2s \
+  your-service.onion
 ```
 
-> [!TIP]
-> **Be Respectful**: The default settings (1s delay, 5MB body limit) are conservative. Only reduce the delay for services you control or have explicit authorization to test aggressively.
+Run `onionscan scan --help` for the complete command reference.
 
-### Secure Logging
+## Main scan options
 
-OnionScan automatically sanitizes sensitive information in log output, even in verbose mode:
+| Flag | Short | Default | Purpose |
+|------|-------|---------|---------|
+| `--external-tor` | `-e` | embedded | Use a SOCKS5 proxy such as `127.0.0.1:9050` |
+| `--tor-timeout` | `-T` | `3m` | Limit embedded Tor startup |
+| `--timeout` | `-t` | `2m` | Limit each network operation |
+| `--depth` | `-d` | `100` | Limit crawl recursion |
+| `--max-pages` | `-p` | `100` | Limit pages per service |
+| `--batch` | `-b` | `10` | Set concurrent target count |
+| `--config` | `-c` | auto | Read a specific configuration file |
+| `--json` | `-j` | off | Write JSON |
+| `--markdown` | `-m` | off | Write Markdown |
+| `--output` | `-o` | stdout | Write the report to a file |
+| `--crawl-delay` | `-D` | `1s` | Pause between crawl requests |
+| `--user-agent` | `-A` | `OnionScan/2.0` | Set the crawler User-Agent |
+| `--max-body-size` | `-B` | `5 MiB` | Limit each response body |
 
-- **Sanitized**: Cookies, Authorization headers, API tokens, passwords, session IDs, private keys
-- **Safe to share**: Logs can be shared for debugging without accidentally exposing secrets
-
-```bash
-# Verbose mode with automatic secret sanitization
-onionscan scan -v exampleonion.onion
-
-# Example output (secrets are masked):
-# INFO request sent cookie=***REDACTED*** url=http://example.onion
-```
-
-### Data Storage
-
-Scan results are automatically saved to a SQLite database following the XDG Base Directory specification:
-
-| OS | Database Location |
-|----|-------------------|
-| Linux | `~/.local/share/onionscan/onionscan.db` |
-| macOS | `~/Library/Application Support/onionscan/onionscan.db` |
-| Windows | `%LOCALAPPDATA%\onionscan\onionscan.db` |
-
-### Compare Scans
-
-OnionScan stores scan results in a local database, allowing you to track changes over time:
-
-```bash
-# Compare latest two scans for a service
-onionscan compare exampleonion.onion
-
-# List all scan history for a service
-onionscan compare -l exampleonion.onion
-
-# List all scanned services in the database
-onionscan compare -L
-
-# Compare with a specific historical scan by ID
-onionscan compare -i 5 exampleonion.onion
-
-# Compare scans since a specific date
-onionscan compare -s "2025-01-01" exampleonion.onion
-
-# Output comparison in JSON format
-onionscan compare -j exampleonion.onion
-
-# Output comparison in Markdown format
-onionscan compare -m exampleonion.onion
-```
-
-The comparison report shows:
-- **New findings**: Issues that appeared since the previous scan
-- **Resolved findings**: Issues that are no longer present
-- **Risk change**: Whether the overall security posture improved, worsened, or stayed the same
+When `--batch` is greater than `1`, site-specific cookies, headers, and depth settings are not applied. Use `--batch 1` when those settings are required.
 
 ## Configuration
 
-### Initialize Configuration File
+Create a documented starter file:
 
-```bash
+```shell
 onionscan init
 ```
 
-This creates `.onionscan` in the current directory with default settings.
-
-### Configuration File Format
+OnionScan looks for `.onionscan` in the current directory and then the home directory. An explicit `--config` path must exist.
 
 ```yaml
-# Default settings for all sites
 defaults:
   cookie: ""
-  depth: 100
+  depth: 50
   headers: {}
   ignore_patterns: []
   follow_patterns: []
 
-# Site-specific configurations
 sites:
-  exampleonion.onion:
-    cookie: "session_id=abc123"
+  your-service.onion:
+    cookie: "session_id=replace-me"
     headers:
-      Authorization: "Bearer token"
-      X-Custom-Header: "value"
-    depth: 50
+      Authorization: "Bearer replace-me"
+    depth: 20
     ignore_patterns:
       - "/logout"
       - "/admin/*"
     follow_patterns:
-      - "/api/*"
       - "/docs/*"
-
-  anotheronion.onion:
-    cookie: "auth=xyz789"
-    depth: 25
 ```
 
-## Report Examples
+Restrict configuration-file permissions because cookies and authorization headers may be sensitive.
 
-### Text Report (Default)
+## Scan history and comparison
 
-```
-======================================================================
-                         ONIONSCAN REPORT
-======================================================================
+Every scan is stored in a local SQLite database. The location follows the XDG conventions used by the operating system.
 
-Hidden Service: exampleonion.onion
-Scan Date:      2025-11-30 14:30:00 UTC
-Pages Crawled:  42
-Status:         Complete
+| Platform | Default database path |
+|----------|-----------------------|
+| Linux | `~/.local/share/onionscan/onionscan.db` |
+| macOS | `~/Library/Application Support/onionscan/onionscan.db` |
+| Windows | `%LOCALAPPDATA%\onionscan\onionscan.db` |
 
-----------------------------------------------------------------------
-SEVERITY SUMMARY
-----------------------------------------------------------------------
+Compare the latest two scans or inspect history:
 
-  CRITICAL: 1
-  HIGH:     3
-  MEDIUM:   5
-  LOW:      2
-  INFO:     4
-
-  TOTAL:    15 findings
-
-----------------------------------------------------------------------
-DETECTED SERVICES
-----------------------------------------------------------------------
-
-  - HTTP (80)
-  - SSH (22)
-
-----------------------------------------------------------------------
-CRITICAL FINDINGS
-----------------------------------------------------------------------
-
-  [!] Private Key Exposed
-      Type:     Tor v3 Hidden Service Private Key
-      Location: /backup/hs_ed25519_secret_key
-
-      The hidden service private key is publicly accessible.
-      Anyone can impersonate this hidden service.
-
-...
+```shell
+onionscan compare your-service.onion
+onionscan compare --list your-service.onion
+onionscan compare --list-services
+onionscan compare --with-scan-id 5 your-service.onion
+onionscan compare --since 2026-01-01 your-service.onion
+onionscan compare --json your-service.onion
+onionscan compare --markdown your-service.onion
 ```
 
-### Markdown Report
+Comparison reports identify new, resolved, and unchanged findings and summarize whether risk improved, worsened, or stayed unchanged.
 
-See [doc/markdown-report.md](doc/markdown-report.md) for a full example.
+## Reports
 
-The Markdown report includes:
-- Summary table with scan metadata
-- Severity distribution pie chart (Mermaid)
-- GitHub-flavored alerts for critical issues
-- Expandable details for each finding
-- Recommendations column
+The default text report is designed for terminals. JSON preserves structured scan data for automation. Markdown produces a reviewable report with severity summaries and detailed findings.
+
+See [the Markdown report example](./doc/markdown-report.md).
+
+Report files are created with owner-only permissions because they can contain sensitive findings.
+
+## Testing
+
+Run the fast Go test suite:
+
+```shell
+make test
+```
+
+Run the real CLI through [atago](https://github.com/nao1215/atago):
+
+```shell
+make e2e
+```
+
+The E2E suite builds a local HTTP fixture, exposes it as an ephemeral Tor v3 onion service with [tornago](https://github.com/nao1215/tornago), and points OnionScan at the fixture's own SOCKS5 proxy. It does not depend on a public onion site. The suite checks version output, configuration generation, JSON scanning, database persistence, and comparison behavior.
+
+Generate one coverage profile from both Go unit tests and the atago-driven CLI runs:
+
+```shell
+make coverage
+```
+
+The command writes `coverage.out` and `coverage.html`. Real-Tor Go integration tests retained for focused debugging are opt-in:
+
+```shell
+make test-integration
+```
 
 ## Troubleshooting
 
-### Embedded Tor fails to start
+### Tor does not start
 
-```
-Error: failed to start embedded Tor: ...
-```
+Check the installed binary and allow more bootstrap time:
 
-**Solutions:**
-1. Ensure Tor is installed on your system (`tor --version`)
-2. Check if another Tor process is already running (`pgrep tor`)
-3. Increase the startup timeout: `onionscan scan --tor-timeout 5m example.onion`
-4. Use an external Tor proxy instead: `onionscan scan -e 127.0.0.1:9050 example.onion`
-
-### Connection timeouts
-
-```
-Error: context deadline exceeded
+```shell
+tor --version
+onionscan scan --tor-timeout 5m your-service.onion
 ```
 
-**Solutions:**
-1. Increase the request timeout: `onionscan scan --timeout 5m example.onion`
-2. Check if the hidden service is online using Tor Browser
-3. Verify your Tor connection is working properly
+You can also use an existing proxy with `--external-tor`.
 
-### Configuration file not found
+### A service times out
 
-```
-Error: configuration file not found: /path/to/config
-```
+Onion services can be slow or offline. Confirm the address in Tor Browser, then increase the request timeout or reduce crawl scope:
 
-When using `--config` with an explicit path, the file must exist. Without `--config`, OnionScan searches for `.onionscan` in:
-1. Current directory
-2. Home directory
-
-If no file is found, default settings are used.
-
-### Out of memory on large sites
-
-For sites with many pages, limit the crawl scope:
-
-```bash
-onionscan scan --max-pages 50 --depth 10 example.onion
+```shell
+onionscan scan --timeout 5m --depth 10 --max-pages 50 your-service.onion
 ```
 
-## Related Projects
+### A configuration file is rejected
 
-- [nao1215/tornago](https://github.com/nao1215/tornago): Go library for Tor daemon management (used by OnionScan)
-- [s-rah/onionscan](https://github.com/s-rah/onionscan): The original OnionScan project that inspired this complete rewrite
+When `--config` is present, OnionScan treats a missing file as an error. Remove the flag to use automatic discovery or provide the correct path.
+
+## Related projects
+
+- [nao1215/tornago](https://github.com/nao1215/tornago) provides the Tor process, client, and hidden-service APIs used by OnionScan.
+- [nao1215/atago](https://github.com/nao1215/atago) verifies OnionScan's real CLI behavior from YAML scenarios.
+- [s-rah/onionscan](https://github.com/s-rah/onionscan) is the original project that inspired this rewrite.
 
 ## Contributing
 
-Contributions are welcome! Please see the [Contributing Guide](./CONTRIBUTING.md) for more details.
+Contributions are welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a change. Security reports should follow [SECURITY.md](./SECURITY.md).
 
-## Support
-
-If you find this project useful, please consider:
-
-- Giving it a star on GitHub - it helps others discover the project
-- [Becoming a sponsor](https://github.com/sponsors/nao1215) - your support keeps the project alive and motivates continued development
+If OnionScan is useful to you, star the repository or [sponsor the maintainer](https://github.com/sponsors/nao1215).
 
 ## License
 

--- a/cmd/onionscan/integration_test.go
+++ b/cmd/onionscan/integration_test.go
@@ -28,6 +28,9 @@ func skipIfShort(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode (requires real Tor, takes 2-5 minutes)")
 	}
+	if os.Getenv("ONIONSCAN_RUN_TOR_INTEGRATION") != "1" {
+		t.Skip("skipping real Tor integration test; set ONIONSCAN_RUN_TOR_INTEGRATION=1 to run it")
+	}
 }
 
 // skipIfNoTor skips the test if the Tor binary is not available.
@@ -188,19 +191,7 @@ func startTestOnionServer(ctx context.Context, t *testing.T) *testOnionServer {
 
 	// Wait for the hidden service to be reachable
 	t.Log("Waiting for hidden service to be reachable...")
-	clientCfg, err := tornago.NewClientConfig(
-		tornago.WithClientSocksAddr(torProcess.SocksAddr()),
-		tornago.WithClientRequestTimeout(30*time.Second),
-	)
-	if err != nil {
-		controlClient.Close()
-		torProcess.Stop()
-		listener.Close()
-		server.Close()
-		t.Fatalf("failed to create client config: %v", err)
-	}
-
-	client, err := tornago.NewClient(clientCfg)
+	client, err := tor.NewClient(torProcess.SocksAddr(), 30*time.Second)
 	if err != nil {
 		controlClient.Close()
 		torProcess.Stop()
@@ -208,10 +199,9 @@ func startTestOnionServer(ctx context.Context, t *testing.T) *testOnionServer {
 		server.Close()
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer client.Close()
-
 	// Poll until the service is reachable (may take up to 2 minutes)
-	httpClient := client.HTTP()
+	httpClient := client.HTTPClient()
+	defer httpClient.CloseIdleConnections()
 	reachable := false
 	for i := range 24 { // 24 attempts, 5 seconds each = 2 minutes max
 		select {

--- a/e2e/atago/onionscan.atago.yaml
+++ b/e2e/atago/onionscan.atago.yaml
@@ -1,0 +1,96 @@
+version: "1"
+
+suite:
+  name: OnionScan CLI with a self-hosted onion service
+  timeout: 3m
+  setup:
+    - service:
+        name: onion-site
+        command: onionscan-e2e-site --state ${suitedir}/site.json
+        ready:
+          file: ${suitedir}/site.json
+          timeout: 6m
+    - store:
+        name: onion_address
+        from:
+          file:
+            path: ${suitedir}/site.json
+            json:
+              path: "$.onion_address"
+    - store:
+        name: socks_address
+        from:
+          file:
+            path: ${suitedir}/site.json
+            json:
+              path: "$.socks_address"
+
+scenarios:
+  - name: version reports the real CLI build
+    steps:
+      - run:
+          command: onionscan version
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "onionscan version v0.0.0-e2e"
+              - "commit: e2e"
+
+  - name: init creates a private configuration template
+    steps:
+      - run:
+          command: onionscan init --output config/onionscan.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "Created configuration file"
+      - assert:
+          file:
+            path: config/onionscan.yaml
+            contains:
+              - "defaults:"
+              - "sites:"
+      - assert:
+          file:
+            path: config/onionscan.yaml
+            executable: false
+
+  - name: scan and compare exercise the self-hosted onion service
+    env:
+      HOME: "${workdir}/home"
+      XDG_CONFIG_HOME: "${workdir}/home/.config"
+      XDG_DATA_HOME: "${workdir}/home/.local/share"
+    steps:
+      - run:
+          command: onionscan scan --external-tor ${socks_address} --timeout 20s --depth 2 --max-pages 5 --crawl-delay 0s --json --output first.json ${onion_address}
+          timeout: 3m
+      - assert:
+          exit_code: 0
+      - assert:
+          file:
+            path: first.json
+            json:
+              - { path: "$.hidden_service", equals: "${onion_address}" }
+              - { path: "$.web_detected", equals: true }
+              - { path: "$.simple_report.pages_crawled", gt: 0 }
+              - { path: "$.timed_out", equals: false }
+      - assert:
+          file:
+            path: first.json
+            contains: "e2e@example.com"
+
+      - run:
+          command: onionscan scan --external-tor ${socks_address} --timeout 20s --depth 1 --max-pages 3 --crawl-delay 0s --json --output second.json ${onion_address}
+          timeout: 3m
+      - assert:
+          exit_code: 0
+
+      - run:
+          command: onionscan compare --json ${onion_address}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - { path: "$.onion_service", equals: "${onion_address}" }
+              - { path: "$.risk_change.direction", equals: "unchanged" }

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Build OnionScan and its tornago-backed onion fixture, then execute the real
+# CLI through atago. The fixture owns both the onion service and the Tor SOCKS
+# proxy, so the suite never depends on a public third-party onion site.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v atago >/dev/null 2>&1; then
+	echo "e2e: atago is not installed; see https://github.com/nao1215/atago" >&2
+	exit 127
+fi
+if ! command -v tor >/dev/null 2>&1; then
+	echo "e2e: tor is not installed" >&2
+	exit 127
+fi
+
+E2E_TMP="$(mktemp -d "${TMPDIR:-/tmp}/onionscan-e2e.XXXXXX")"
+cleanup() {
+	chmod -R u+w "$E2E_TMP" >/dev/null 2>&1 || true
+	rm -rf "$E2E_TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$E2E_TMP/bin"
+
+COVER_FLAGS=()
+if [ -n "${COVER:-}" ]; then
+	COVER_FLAGS=(-cover -covermode=atomic -coverpkg=./...)
+	echo "e2e: building coverage-instrumented OnionScan"
+fi
+
+echo "e2e: building OnionScan and the tornago onion service"
+(
+	cd "$REPO_ROOT"
+	go build "${COVER_FLAGS[@]}" \
+		-ldflags '-X main.version=v0.0.0-e2e -X main.commit=e2e -X main.date=1970-01-01T00:00:00Z' \
+		-o "$E2E_TMP/bin/onionscan" ./cmd/onionscan
+	go build -o "$E2E_TMP/bin/onionscan-e2e-site" ./e2e/tornago-site
+)
+
+export PATH="$E2E_TMP/bin:$PATH"
+atago run --parallel 1 "$@" "$SCRIPT_DIR/atago"

--- a/e2e/tornago-site/main.go
+++ b/e2e/tornago-site/main.go
@@ -1,0 +1,245 @@
+// Package main provides the controlled Tornago onion fixture used by the E2E suite.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	onionscantor "github.com/nao1215/onionscan/internal/tor"
+	"github.com/nao1215/tornago"
+)
+
+const testPage = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>OnionScan E2E Service</title>
+</head>
+<body>
+  <h1>OnionScan E2E Service</h1>
+  <p>This onion service is owned by the OnionScan test suite.</p>
+  <p>Contact: e2e@example.com</p>
+  <p>Bitcoin: 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa</p>
+  <a href="/about">About this service</a>
+</body>
+</html>`
+
+type siteState struct {
+	OnionAddress string `json:"onion_address"`
+	OnionURL     string `json:"onion_url"`
+	SocksAddress string `json:"socks_address"`
+}
+
+func main() {
+	statePath := flag.String("state", "", "path to write the ready-state JSON file")
+	flag.Parse()
+
+	if *statePath == "" {
+		fmt.Fprintln(os.Stderr, "tornago-site: --state is required")
+		os.Exit(2)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, *statePath); err != nil {
+		fmt.Fprintf(os.Stderr, "tornago-site: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, statePath string) error {
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("listen for local HTTP: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Server", "onionscan-e2e/1.0")
+		_, _ = fmt.Fprint(w, testPage)
+	})
+	mux.HandleFunc("/about", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, "<html><title>About</title><body>Controlled by OnionScan E2E.</body></html>")
+	})
+
+	httpServer := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	serverErrors := make(chan error, 1)
+	go func() {
+		serveErr := httpServer.Serve(listener)
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			serverErrors <- serveErr
+		}
+	}()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if shutdownErr := httpServer.Shutdown(shutdownCtx); shutdownErr != nil {
+			fmt.Fprintf(os.Stderr, "tornago-site: shut down HTTP server: %v\n", shutdownErr)
+		}
+	}()
+
+	localPort, err := listenerPort(listener)
+	if err != nil {
+		return err
+	}
+
+	launchConfig, err := tornago.NewTorLaunchConfig(
+		tornago.WithTorSocksAddr(":0"),
+		tornago.WithTorControlAddr(":0"),
+		tornago.WithTorStartupTimeout(5*time.Minute),
+	)
+	if err != nil {
+		return fmt.Errorf("configure Tor: %w", err)
+	}
+
+	torProcess, err := tornago.StartTorDaemon(launchConfig)
+	if err != nil {
+		return fmt.Errorf("start Tor: %w", err)
+	}
+	defer func() { _ = torProcess.Stop() }()
+
+	auth, _, err := tornago.ControlAuthFromTor(torProcess.ControlAddr(), 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("discover Tor control authentication: %w", err)
+	}
+	controlClient, err := tornago.NewControlClient(torProcess.ControlAddr(), auth, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("create Tor control client: %w", err)
+	}
+	defer func() { _ = controlClient.Close() }()
+
+	if err := controlClient.Authenticate(); err != nil {
+		return fmt.Errorf("authenticate Tor control client: %w", err)
+	}
+
+	hiddenServiceConfig, err := tornago.NewHiddenServiceConfig(
+		tornago.WithHiddenServiceHTTP(localPort),
+	)
+	if err != nil {
+		return fmt.Errorf("configure hidden service: %w", err)
+	}
+	hiddenService, err := controlClient.CreateHiddenService(ctx, hiddenServiceConfig)
+	if err != nil {
+		return fmt.Errorf("create hidden service: %w", err)
+	}
+	defer func() {
+		removeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if removeErr := hiddenService.Remove(removeCtx); removeErr != nil {
+			fmt.Fprintf(os.Stderr, "tornago-site: remove hidden service: %v\n", removeErr)
+		}
+	}()
+
+	state := siteState{
+		OnionAddress: hiddenService.OnionAddress(),
+		OnionURL:     "http://" + hiddenService.OnionAddress(),
+		SocksAddress: torProcess.SocksAddr(),
+	}
+	if err := waitUntilReachable(ctx, state); err != nil {
+		return err
+	}
+	if err := writeState(statePath, state); err != nil {
+		return err
+	}
+
+	fmt.Printf("ready onion=%s socks=%s\n", state.OnionAddress, state.SocksAddress)
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case serveErr := <-serverErrors:
+		return fmt.Errorf("serve local HTTP: %w", serveErr)
+	}
+}
+
+func listenerPort(listener net.Listener) (int, error) {
+	address, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected listener address %T", listener.Addr())
+	}
+	return address.Port, nil
+}
+
+func waitUntilReachable(ctx context.Context, state siteState) error {
+	client, err := onionscantor.NewClient(state.SocksAddress, 15*time.Second)
+	if err != nil {
+		return fmt.Errorf("create OnionScan Tor client: %w", err)
+	}
+	httpClient := client.HTTPClient()
+	defer httpClient.CloseIdleConnections()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		requestCtx, requestCancel := context.WithTimeout(waitCtx, 15*time.Second)
+		request, requestErr := http.NewRequestWithContext(requestCtx, http.MethodGet, state.OnionURL, http.NoBody)
+		if requestErr == nil {
+			response, doErr := httpClient.Do(request)
+			if doErr == nil {
+				_ = response.Body.Close()
+				if response.StatusCode == http.StatusOK {
+					requestCancel()
+					return nil
+				}
+				lastErr = fmt.Errorf("unexpected HTTP status %s", response.Status)
+			} else {
+				lastErr = doErr
+			}
+		} else {
+			lastErr = requestErr
+		}
+		requestCancel()
+
+		select {
+		case <-waitCtx.Done():
+			if lastErr == nil {
+				return fmt.Errorf("hidden service did not become reachable: %w", waitCtx.Err())
+			}
+			return fmt.Errorf(
+				"hidden service did not become reachable: %w",
+				errors.Join(waitCtx.Err(), fmt.Errorf("last request: %w", lastErr)),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func writeState(path string, state siteState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create state directory: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode state: %w", err)
+	}
+	data = append(data, '\n')
+
+	temporaryPath := path + ".tmp"
+	if err := os.WriteFile(temporaryPath, data, 0o600); err != nil {
+		return fmt.Errorf("write temporary state: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish state: %w", err)
+	}
+	return nil
+}

--- a/internal/tor/client.go
+++ b/internal/tor/client.go
@@ -36,6 +36,11 @@ type Client struct {
 	// We cache this to avoid recreating it for each connection.
 	dialer proxy.Dialer
 
+	// contextDialer is the context-aware form of dialer. Keeping this separately
+	// ensures cancellation interrupts both the TCP connection and the SOCKS5
+	// handshake instead of leaving a background dial blocked indefinitely.
+	contextDialer proxy.ContextDialer
+
 	// timeout is the default timeout for connections.
 	timeout time.Duration
 }
@@ -58,17 +63,25 @@ func NewClient(proxyAddress string, timeout time.Duration) (*Client, error) {
 		return nil, ErrInvalidProxyAddress
 	}
 
-	// Create the SOCKS5 dialer
-	// We use nil for auth because Tor's SOCKS port typically doesn't require auth
-	dialer, err := proxy.SOCKS5("tcp", proxyAddress, nil, proxy.Direct)
+	// Create the SOCKS5 dialer. A net.Dialer is used as the forward dialer so
+	// connecting to the proxy has the same upper bound as the rest of the
+	// request. x/net's SOCKS5 dialer also applies context deadlines to its
+	// handshake when the forward dialer supports DialContext.
+	forwardDialer := &net.Dialer{Timeout: timeout}
+	dialer, err := proxy.SOCKS5("tcp", proxyAddress, nil, forwardDialer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SOCKS5 dialer: %w", err)
 	}
+	contextDialer, ok := dialer.(proxy.ContextDialer)
+	if !ok {
+		return nil, errors.New("SOCKS5 dialer does not support context cancellation")
+	}
 
 	return &Client{
-		proxyAddress: proxyAddress,
-		dialer:       dialer,
-		timeout:      timeout,
+		proxyAddress:  proxyAddress,
+		dialer:        dialer,
+		contextDialer: contextDialer,
+		timeout:       timeout,
 	}, nil
 }
 
@@ -258,8 +271,8 @@ func (c *Client) NewHTTPClient() *http.Client {
 	// Create transport that routes through Tor
 	transport := &http.Transport{
 		// Use our SOCKS5 dialer for all connections
-		DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
-			return c.dialer.Dial(network, addr)
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return c.DialContext(ctx, network, addr)
 		},
 		// Disable TLS verification because hidden services typically use
 		// self-signed certificates. The .onion address itself provides
@@ -305,37 +318,41 @@ func (c *Client) NewHTTPClient() *http.Client {
 // The address should be in "host:port" format. For hidden services,
 // use the .onion address (e.g., "example.onion:22").
 func (c *Client) Dial(network, address string) (net.Conn, error) {
-	return c.dialer.Dial(network, address)
+	ctx := context.Background()
+	if c.timeout <= 0 {
+		return c.contextDialer.DialContext(ctx, network, address)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	conn, err := c.contextDialer.DialContext(ctx, network, address)
+	if err != nil && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return conn, err
 }
 
 // DialContext establishes a TCP connection through Tor with context support.
 // This allows for timeout and cancellation control.
 //
-// Design decision: We wrap the basic Dial with context support because
-// the proxy.Dialer interface doesn't support context directly. If the context
-// is cancelled, the goroutine returns the error but the underlying connection
-// attempt may continue briefly. This is a known limitation of the approach.
+// The configured client timeout is an upper bound even when the caller's
+// context has no deadline. If the caller supplies a shorter deadline, the
+// standard context rules preserve that shorter bound.
 func (c *Client) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	// Create channels for result and error
-	type dialResult struct {
-		conn net.Conn
-		err  error
+	if ctx == nil {
+		return nil, errors.New("dial context must not be nil")
 	}
-	resultCh := make(chan dialResult, 1)
-
-	// Dial in a goroutine so we can respect context cancellation
-	go func() {
-		conn, err := c.dialer.Dial(network, address)
-		resultCh <- dialResult{conn, err}
-	}()
-
-	// Wait for either the dial to complete or context cancellation
-	select {
-	case result := <-resultCh:
-		return result.conn, result.err
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if c.timeout <= 0 {
+		return c.contextDialer.DialContext(ctx, network, address)
 	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	conn, err := c.contextDialer.DialContext(dialCtx, network, address)
+	if err != nil && dialCtx.Err() != nil {
+		return nil, dialCtx.Err()
+	}
+	return conn, err
 }
 
 // ProxyAddress returns the configured proxy address.

--- a/internal/tor/client.go
+++ b/internal/tor/client.go
@@ -326,10 +326,10 @@ func (c *Client) Dial(network, address string) (net.Conn, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	conn, err := c.contextDialer.DialContext(ctx, network, address)
-	if err != nil && ctx.Err() != nil {
-		return nil, ctx.Err()
+	if normalizedErr := normalizeDialError(ctx, err); normalizedErr != nil {
+		return nil, normalizedErr
 	}
-	return conn, err
+	return conn, nil
 }
 
 // DialContext establishes a TCP connection through Tor with context support.
@@ -349,10 +349,28 @@ func (c *Client) DialContext(ctx context.Context, network, address string) (net.
 	dialCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	conn, err := c.contextDialer.DialContext(dialCtx, network, address)
-	if err != nil && dialCtx.Err() != nil {
-		return nil, dialCtx.Err()
+	if normalizedErr := normalizeDialError(dialCtx, err); normalizedErr != nil {
+		return nil, normalizedErr
 	}
-	return conn, err
+	return conn, nil
+}
+
+// normalizeDialError gives callers consistent context errors across platforms.
+// Some operating systems report the deadline applied by x/net/proxy as an
+// ordinary network timeout just before the context timer becomes observable.
+func normalizeDialError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if contextErr := ctx.Err(); contextErr != nil {
+		return contextErr
+	}
+
+	var networkErr net.Error
+	if _, hasDeadline := ctx.Deadline(); hasDeadline && errors.As(err, &networkErr) && networkErr.Timeout() {
+		return context.DeadlineExceeded
+	}
+	return err
 }
 
 // ProxyAddress returns the configured proxy address.

--- a/internal/tor/client_test.go
+++ b/internal/tor/client_test.go
@@ -3,6 +3,7 @@ package tor
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -661,6 +662,64 @@ func TestDialContext(t *testing.T) {
 		_, err := client.DialContext(ctx, "tcp", "example.onion:80")
 		if err == nil {
 			t.Log("DialContext succeeded (Tor proxy may be running)")
+		}
+	})
+
+	t.Run("cancels a stalled SOCKS5 handshake", func(t *testing.T) {
+		t.Parallel()
+
+		listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to create listener: %v", err)
+		}
+		defer listener.Close()
+
+		serverDone := make(chan struct{})
+		go func() {
+			defer close(serverDone)
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			defer conn.Close()
+
+			greeting := make([]byte, 3)
+			if _, readErr := io.ReadFull(conn, greeting); readErr != nil {
+				return
+			}
+			if _, writeErr := conn.Write([]byte{0x05, 0x00}); writeErr != nil {
+				return
+			}
+
+			// Read the CONNECT request, then intentionally omit the reply. A
+			// context-aware SOCKS5 handshake must still return and close conn.
+			request := make([]byte, 4+1+len("example.onion")+2)
+			_, _ = io.ReadFull(conn, request)
+			oneByte := make([]byte, 1)
+			_, _ = conn.Read(oneByte)
+		}()
+
+		client, err := NewClient(listener.Addr().String(), 5*time.Second)
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		started := time.Now()
+		_, err = client.DialContext(ctx, "tcp", "example.onion:80")
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context deadline exceeded, got %v", err)
+		}
+		if elapsed := time.Since(started); elapsed > time.Second {
+			t.Fatalf("stalled handshake ignored cancellation for %v", elapsed)
+		}
+
+		select {
+		case <-serverDone:
+		case <-time.After(time.Second):
+			t.Fatal("SOCKS5 connection remained open after cancellation")
 		}
 	})
 }

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Merge package-level unit coverage with runtime coverage from the real CLI
+# exercised by atago. Both producers use atomic covdata so Go can combine them
+# into one coverage.out consumed by octocov and local tooling.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COVERAGE_ROOT="$REPO_ROOT/.coverage"
+rm -rf "$COVERAGE_ROOT"
+mkdir -p "$COVERAGE_ROOT/unit" "$COVERAGE_ROOT/e2e" "$COVERAGE_ROOT/merged"
+
+echo ">> unit coverage"
+go test -short -count=1 -cover -covermode=atomic -coverpkg=./... ./... \
+	-args -test.gocoverdir="$COVERAGE_ROOT/unit"
+
+echo ">> atago E2E coverage"
+COVER=1 GOCOVERDIR="$COVERAGE_ROOT/e2e" "$REPO_ROOT/e2e/run.sh"
+
+echo ">> merge unit and E2E coverage"
+go tool covdata merge -i="$COVERAGE_ROOT/unit,$COVERAGE_ROOT/e2e" -o="$COVERAGE_ROOT/merged"
+go tool covdata textfmt -i="$COVERAGE_ROOT/merged" -o="$REPO_ROOT/coverage.out"
+go tool cover -func=coverage.out | tail -n 1
+go tool cover -html=coverage.out -o coverage.html
+echo ">> wrote coverage.out and coverage.html"


### PR DESCRIPTION
## Summary

- make SOCKS5 dialing honor context cancellation and configured timeouts
- replace flaky default real-Tor integration execution with an opt-in path
- add atago E2E against a self-hosted tornago onion service
- merge unit and CLI runtime coverage into one report
- refresh the README without bold text and add the tested-with-atago badge

## Test plan

- make e2e: 3 passed
- make coverage: 82.9% combined coverage
- go test -race -short -count=1 ./...
- go vet ./...
- golangci-lint run --new-from-rev=origin/main: 0 issues
- actionlint .github/workflows/*.yml