### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## v0.2.2 - 2026-08-23
+
+### Fixed
+
+- Prevent canceled non-HTTP protocol scans from retaining blocked dial goroutines by requiring context-aware proxy dialers.
+- Inject version, commit, and build date into the CLI variables used by release binaries.
+- Make Tor-backed E2E coverage resilient to transient circuit construction failures.
+
+### Changed
+
+- Add a tornago-hosted onion fixture and five atago scenarios covering version, init, scan, compare, batch, external Tor, and embedded Tor behavior.
+- Combine unit and E2E coverage across production packages and raise the enforced threshold to 95%.
+- Expand boundary and failure-path tests across the CLI, crawler, database, deanonymization analyzers, model, pipeline, protocols, reports, and Tor client.
+- Migrate the GoReleaser configuration to schema version 2 and the current Homebrew cask format.
+- Use the standard library SHA-3 implementation for Tor v3 checksum validation.
+
+### Dependencies
+
+- Update actions/checkout and actions/setup-go to version 7.
+- Update github.com/nao1215/markdown to 1.0.0.
+- Update modernc.org/sqlite to 1.56.0.
+- Update golang.org/x/crypto to 0.55.0, golang.org/x/net to 0.58.0, golang.org/x/sync to 0.22.0, and golang.org/x/text to 0.41.0.
+
+[Full changes](https://github.com/nao1215/onionscan/compare/v0.2.1...v0.2.2)


### PR DESCRIPTION
## Summary

Prepare the v0.2.2 patch release after the protocol cancellation, release metadata, coverage, and Tor E2E fixes were merged.

## Changes

- Add a changelog entry covering fixes, quality improvements, E2E coverage, release tooling, and dependency updates since v0.2.1.
- Document the 95% combined unit and atago E2E coverage threshold.
- Link the complete v0.2.1-to-v0.2.2 comparison.

## Design Decisions

- Use a patch release because the changes harden existing behavior, repair release artifacts, and update dependencies without adding a new public feature contract.
- Keep release notes in a tracked changelog so the release PR has a reviewable artifact before tagging.

## Limitations

- The GitHub comparison link resolves fully after the v0.2.2 tag is pushed.