### PR TITLE
docs(readme): document the onionscan-bin AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ choco install tor
 brew install nao1215/tap/onionscan
 ```
 
+### Arch Linux (AUR)
+
+```shell
+yay -S onionscan-bin   # or: paru -S onionscan-bin
+```
+
+[`onionscan-bin`](https://aur.archlinux.org/packages/onionscan-bin) is community-maintained and installs the release binary.
+
 ### Go
 
 ```shell


### PR DESCRIPTION
[`onionscan-bin`](https://aur.archlinux.org/packages/onionscan-bin) (currently 0.2.2, matching the latest tag) tracks this repository's release binaries on the AUR, but the README's Install section listed only Homebrew, `go install`, and a source build.

Naming the package explicitly matters here: the AUR also carries an `onionscan` package built from the original upstream project, so `yay -S onionscan` gets a different tool.

README only; no other install route changed. onionscan has no documentation site to mirror this into.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions for Arch Linux users through the AUR.
  * Documented installation options using `yay` and `paru`.
  * Noted that the AUR package is community-maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->